### PR TITLE
fix: initialize allocated cuda memory to 0

### DIFF
--- a/lib/hais_ops/src/hierarchical_aggregation/hierarchical_aggregation.cu
+++ b/lib/hais_ops/src/hierarchical_aggregation/hierarchical_aggregation.cu
@@ -138,6 +138,9 @@ void hierarchical_aggregation_cuda(
     int *cuda_primary_absorb_fragment_cnt; // array for saving the fragment nums
     cudaMalloc((void**)&cuda_primary_absorb_fragment_idx, primary_num * MAX_PER_PRIMARY_ABSORB_FRAGMENT_NUM * sizeof(int) + sizeof(int));
     cudaMalloc((void**)&cuda_primary_absorb_fragment_cnt, primary_num * sizeof(int) + sizeof(int));
+    cudaMemset(cuda_primary_absorb_fragment_idx, 0, primary_num * MAX_PER_PRIMARY_ABSORB_FRAGMENT_NUM * sizeof(int) + sizeof(int));
+    cudaMemset(cuda_primary_absorb_fragment_cnt, 0, primary_num * sizeof(int) + sizeof(int));
+
     if (fragment_num != 0)
         fragment_find_primary_<<<int(DIVUP(fragment_num, MAX_THREADS_PER_BLOCK)), (int)MAX_THREADS_PER_BLOCK>>>(
             primary_num, cuda_primary_offsets, cuda_primary_centers,


### PR DESCRIPTION
The allocated CUDA memory was not initialized but was assumed to be all 0, which may cause `CUDA kernel failed: an illegal memory access was encountered`. `cudaMemset` code was added to fix this problem.